### PR TITLE
Implemented homework 1 requirements

### DIFF
--- a/restapi/Controllers/RootController.cs
+++ b/restapi/Controllers/RootController.cs
@@ -24,7 +24,14 @@ namespace restapi.Controllers
                             Type = ContentTypes.Timesheets,
                             Relationship = DocumentRelationship.Timesheets,
                             Reference = "/timesheets"
-                        }
+                        },
+                        new DocumentLink() 
+                        { 
+                            Method = Method.Post,
+                            Type = ContentTypes.Timesheet,
+                            Relationship = DocumentRelationship.CreateTimesheet,
+                            Reference = "/timesheets"
+                        }   
                     }
                 },
                 {

--- a/restapi/Controllers/TimesheetsController.cs
+++ b/restapi/Controllers/TimesheetsController.cs
@@ -525,11 +525,10 @@ namespace restapi.Controllers
                 }
 
                 // Check for Line on Timecard
-                TimecardLine annotatedTimecardLine = timecard.GetLine(lineId);
+                TimecardLine timecardLine = timecard.GetLine(lineId);
              
                 // Delete Existing Line from Timecard
-                timecard.RemoveLine(annotatedTimecardLine);
-                Console.WriteLine("Standard Numeric Format Specifiers");
+                timecard.RemoveLine(timecardLine);
 
                 // Add New Line
                 var updatedLine = timecard.AddLine(documentLine);
@@ -553,9 +552,6 @@ namespace restapi.Controllers
             logger.LogInformation($"Looking for timesheet {id}");
 
             Timecard timecard = repository.Find(id);
-            if (timecard == null) {
-                return NotFound();
-            }
 
             if (timecard != null && timecard.HasLine(lineId))
             {
@@ -564,30 +560,30 @@ namespace restapi.Controllers
                     return StatusCode(409, new InvalidStateError() { });
                 }
                 
-                TimecardLine annotatedTimecardLine = timecard.GetLine(lineId);
+                TimecardLine timecardLine = timecard.GetLine(lineId);
                 // Update day
                 if(documentLine.Day != null)
-                    annotatedTimecardLine.Day = documentLine.Day;
+                    timecardLine.Day = documentLine.Day;
 
                 // Update week
                 if(documentLine.Week != -1)
-                    annotatedTimecardLine.Week = documentLine.Week;
+                    timecardLine.Week = documentLine.Week;
 
                 // Update year
                 if(documentLine.Year != -1)
-                    annotatedTimecardLine.Year = documentLine.Year;
+                    timecardLine.Year = documentLine.Year;
 
                 // Update hours
                 if(documentLine.Hours != -1)
-                    annotatedTimecardLine.Hours = documentLine.Hours;
+                    timecardLine.Hours = documentLine.Hours;
 
                 // Update project
                 if(documentLine.Project != null)
-                    annotatedTimecardLine.Project = documentLine.Project;
+                    timecardLine.Project = documentLine.Project;
 
                 repository.Update(timecard);
 
-                return Ok(annotatedTimecardLine);
+                return Ok(timecardLine);
             }
             else
             {

--- a/restapi/Controllers/TimesheetsController.cs
+++ b/restapi/Controllers/TimesheetsController.cs
@@ -264,7 +264,7 @@ namespace restapi.Controllers
                     return StatusCode(409, new InvalidStateError() { });
                 }
                 
-                if(timecard.Employee == cancellation.Person){
+                if(timecard.Status == TimecardStatus.Draft && timecard.Employee != cancellation.Person){
                     return StatusCode(409, new InvalidStateError() { });
                 }
                 

--- a/restapi/Controllers/TimesheetsController.cs
+++ b/restapi/Controllers/TimesheetsController.cs
@@ -304,11 +304,6 @@ namespace restapi.Controllers
                     return StatusCode(409, new InvalidStateError() { });
                 }
                 
-                // Timecard employee can cancel and correct his own timecard
-                if(timecard.Employee != cancellation.Person){
-                    return StatusCode(409, new InvalidStateError() { });
-                }
-
                 var transition = new Transition(cancellation,TimecardStatus.Draft);
 
                 logger.LogInformation($"Adding correction transition {transition}");

--- a/restapi/Controllers/TimesheetsController.cs
+++ b/restapi/Controllers/TimesheetsController.cs
@@ -557,12 +557,6 @@ namespace restapi.Controllers
                 return NotFound();
             }
 
-            // logger.LogInformation($"Looking for timesheet line {lineId}");
-            // TimecardLine annotatedTimecardLine = timecard.GetLine(lineId);
-            // if(annotatedTimecardLine == null ){
-            //     return NotFound();
-            // }
-
             if (timecard != null && timecard.HasLine(lineId))
             {
                 if (timecard.Status != TimecardStatus.Draft)

--- a/restapi/Controllers/TimesheetsController.cs
+++ b/restapi/Controllers/TimesheetsController.cs
@@ -172,6 +172,7 @@ namespace restapi.Controllers
         [ProducesResponseType(404)]
         [ProducesResponseType(typeof(InvalidStateError), 409)]
         [ProducesResponseType(typeof(EmptyTimecardError), 409)]
+        [ProducesResponseType(typeof(AuthorizationError), 401)]
         public IActionResult Submit(Guid id, [FromBody] Submittal submittal)
         {
             logger.LogInformation($"Looking for timesheet {id}");
@@ -193,7 +194,7 @@ namespace restapi.Controllers
                 // Timecard employee cannot submit other's timecard
                 if(timecard.Employee != submittal.Person)
                 {
-                    return StatusCode(409, new InvalidStateError() { });
+                    return StatusCode(401, new AuthorizationError() { });
                 }
 
                 var transition = new Transition(submittal, TimecardStatus.Submitted);
@@ -251,6 +252,7 @@ namespace restapi.Controllers
         [ProducesResponseType(404)]
         [ProducesResponseType(typeof(InvalidStateError), 409)]
         [ProducesResponseType(typeof(EmptyTimecardError), 409)]
+        [ProducesResponseType(typeof(AuthorizationError), 401)]
         public IActionResult Cancel(Guid id, [FromBody] Cancellation cancellation)
         {
             logger.LogInformation($"Looking for timesheet {id}");
@@ -265,7 +267,7 @@ namespace restapi.Controllers
                 }
                 
                 if(timecard.Status == TimecardStatus.Draft && timecard.Employee != cancellation.Person){
-                    return StatusCode(409, new InvalidStateError() { });
+                     return StatusCode(401, new AuthorizationError() { });
                 }
                 
                 var transition = new Transition(cancellation, TimecardStatus.Cancelled);
@@ -290,6 +292,7 @@ namespace restapi.Controllers
         [ProducesResponseType(404)]
         [ProducesResponseType(typeof(InvalidStateError), 409)]
         [ProducesResponseType(typeof(EmptyTimecardError), 409)]
+        [ProducesResponseType(typeof(AuthorizationError), 401)]
         public IActionResult Correct(Guid id, [FromBody] Cancellation cancellation)
         {
             logger.LogInformation($"Looking for timesheet {id}");
@@ -299,9 +302,14 @@ namespace restapi.Controllers
             if (timecard != null)
             {
                 
-                if (timecard.Status != TimecardStatus.Submitted && timecard.Employee != cancellation.Person)
+                if (timecard.Status != TimecardStatus.Submitted)
                 {
                     return StatusCode(409, new InvalidStateError() { });
+                }
+
+                if (timecard.Employee != cancellation.Person)
+                {
+                     return StatusCode(401, new AuthorizationError() { });
                 }
                 
                 var transition = new Transition(cancellation,TimecardStatus.Draft);
@@ -359,6 +367,7 @@ namespace restapi.Controllers
         [ProducesResponseType(404)]
         [ProducesResponseType(typeof(InvalidStateError), 409)]
         [ProducesResponseType(typeof(EmptyTimecardError), 409)]
+        [ProducesResponseType(typeof(AuthorizationError), 401)]
         public IActionResult Reject(Guid id, [FromBody] Rejection rejection)
         {
             logger.LogInformation($"Looking for timesheet {id}");
@@ -375,7 +384,7 @@ namespace restapi.Controllers
                 // A Person cannot reject his own timecard
                 if(timecard.Employee == rejection.Person)
                 {
-                    return StatusCode(409, new InvalidStateError() { });
+                     return StatusCode(401, new AuthorizationError() { });
                 }
 
                 var transition = new Transition(rejection, TimecardStatus.Rejected);
@@ -433,6 +442,7 @@ namespace restapi.Controllers
         [ProducesResponseType(404)]
         [ProducesResponseType(typeof(InvalidStateError), 409)]
         [ProducesResponseType(typeof(EmptyTimecardError), 409)]
+        [ProducesResponseType(typeof(AuthorizationError), 401)]
         public IActionResult Approve(Guid id, [FromBody] Approval approval)
         {
             logger.LogInformation($"Looking for timesheet {id}");
@@ -449,7 +459,7 @@ namespace restapi.Controllers
                 // Timecard employee cannot approve his own timecard
                 if(timecard.Employee == approval.Person)
                 {
-                    return StatusCode(409, new InvalidStateError() { });
+                     return StatusCode(401, new AuthorizationError() { });
                 }
 
                 var transition = new Transition(approval, TimecardStatus.Approved);

--- a/restapi/Models/ActionRelationship.cs
+++ b/restapi/Models/ActionRelationship.cs
@@ -10,6 +10,14 @@ namespace restapi.Models
 
         Approve,
 
-        RecordLine
+        RecordLine,
+
+        Remove,
+
+        ReplaceLine,
+
+        UpdateLine,
+
+        ReturnForCorrection,
     }
 }

--- a/restapi/Models/ErrorMessages.cs
+++ b/restapi/Models/ErrorMessages.cs
@@ -20,4 +20,11 @@ namespace restapi.Models
 
         public string Message { get => "No state transition of requested type present in timecard"; }
     }
+
+    public class AuthorizationError
+    {
+        public int ErrorCode { get => 103; }
+
+        public string Message { get => "You do not have access to do this action"; }
+    }
 }

--- a/restapi/Models/Method.cs
+++ b/restapi/Models/Method.cs
@@ -5,6 +5,7 @@ namespace restapi.Models
         Get,
         Post,
         Put,
-        Delete
+        Delete,
+        Patch
     }
 }

--- a/restapi/Models/Timecard.cs
+++ b/restapi/Models/Timecard.cs
@@ -153,7 +153,7 @@ namespace restapi.Models
                     break;
 
                 case TimecardStatus.Cancelled:
-                    // terminal state, nothing possible here
+                    
                     links.Add(new ActionLink()
                     {
                         Method = Method.Delete,

--- a/restapi/Models/Timecard.cs
+++ b/restapi/Models/Timecard.cs
@@ -90,9 +90,38 @@ namespace restapi.Models
                         Reference = $"/timesheets/{UniqueIdentifier}/lines"
                     });
 
+                    links.Add(new ActionLink()
+                    {
+                        Method = Method.Delete,
+                        Relationship = ActionRelationship.Remove,
+                        Reference = $"/timesheets/{UniqueIdentifier}"
+                    });
+
+                    links.Add(new ActionLink()
+                    {
+                        Method = Method.Post,
+                        Relationship = ActionRelationship.ReplaceLine,
+                        Reference = $"/timesheets/{UniqueIdentifier}/lines/{UniqueIdentifier}"
+                    });
+
+                    links.Add(new ActionLink()
+                    {
+                        Method = Method.Patch,
+                        Relationship = ActionRelationship.UpdateLine,
+                        Reference = $"/timesheets/{UniqueIdentifier}/lines/{UniqueIdentifier}"
+                    });
+
                     break;
 
                 case TimecardStatus.Submitted:
+                    links.Add(new ActionLink()
+                    {
+                        Method = Method.Post,
+                        Type = ContentTypes.Cancellation,
+                        Relationship = ActionRelationship.ReturnForCorrection,
+                        Reference = $"/timesheets/{UniqueIdentifier}/correction"
+                    });
+
                     links.Add(new ActionLink()
                     {
                         Method = Method.Post,
@@ -125,6 +154,12 @@ namespace restapi.Models
 
                 case TimecardStatus.Cancelled:
                     // terminal state, nothing possible here
+                    links.Add(new ActionLink()
+                    {
+                        Method = Method.Delete,
+                        Relationship = ActionRelationship.Remove,
+                        Reference = $"/timesheets/{UniqueIdentifier}"
+                    });
                     break;
             }
 
@@ -188,10 +223,18 @@ namespace restapi.Models
                 .Any(l => l.UniqueIdentifier == lineId);
         }
 
-
         public override string ToString()
         {
             return PublicJsonSerializer.SerializeObjectIndented(this);
+        }
+
+        public TimecardLine GetLine(Guid lineId)
+        {
+            return Lines.Where(l => l.UniqueIdentifier == lineId).First();
+        }
+
+        public void RemoveLine(TimecardLine line) {
+            Lines.Remove(line);
         }
     }
 }

--- a/restapi/Models/Timecard.cs
+++ b/restapi/Models/Timecard.cs
@@ -100,6 +100,7 @@ namespace restapi.Models
                     links.Add(new ActionLink()
                     {
                         Method = Method.Post,
+                        Type = ContentTypes.TimesheetLine,
                         Relationship = ActionRelationship.ReplaceLine,
                         Reference = $"/timesheets/{UniqueIdentifier}/lines/{UniqueIdentifier}"
                     });
@@ -107,6 +108,7 @@ namespace restapi.Models
                     links.Add(new ActionLink()
                     {
                         Method = Method.Patch,
+                        Type = ContentTypes.TimesheetLine,
                         Relationship = ActionRelationship.UpdateLine,
                         Reference = $"/timesheets/{UniqueIdentifier}/lines/{UniqueIdentifier}"
                     });


### PR DESCRIPTION
Added support (state management, semantics, etc.) for following:
Remove (DELETE) a draft or cancelled timecard
Replace (POST) a complete line item
Update (PATCH) a line item
Verify that timecard person is consistent throughout the timecard's lifetime
Verify that timecard approver is not timecard person
Add support to root document for creating a timesheet

Added transition back to the draft state

Cancellation in state diagram is little confusing. So I have set it to following rules
Rules for Cancellation:
For cancellation, employee can cancel his own timecard if it is draft state.
If timecard is in submitted state, only other employee can cancel it.

Employee can correct his timecard  only if it is in submitted state.